### PR TITLE
Add more soul types.

### DIFF
--- a/denizen_scripts/survival/repo-link/items/system/soul_item_system.dsc
+++ b/denizen_scripts/survival/repo-link/items/system/soul_item_system.dsc
@@ -54,32 +54,51 @@ item_system_global_data:
     ####### COMMON #######
     ######## buff ########
     0:
-      basher: melee_damage/buff
-      sprinter: speed/buff
+      armadillo: armor/buff
+      rusher: attack_speed/buff
       cow: health/buff
+      basher: melee_damage/buff
+      hawk: ranged_damage/buff
+      sprinter: speed/buff
     ###### UNCOMMON ######
     ## buff/buff/debuff ##
     1:
-      barbarian: melee_damage/buff|ranged_damage/buff|speed/debuff
-      kamikaze: melee_damage/buff|ranged_damage/buff|health/debuff
-      beater: melee_damage/buff|ranged_damage/buff|attack_speed/debuff
-      silverstrike: melee_damage/buff|speed/buff|health/debuff
+      fighter: armor/buff|attack_speed/buff|health/debuff
+      frontier: armor/buff|attack_speed/buff|ranged_damage/debuff
+      wyvern: armor/buff|health/buff|ranged_damage/debuff
+      turtle: armor/buff|health/buff|speed/debuff
+      journeyman: armor/buff|melee_damage/buff|health/debuff
+      sniper: armor/buff|ranged_damaged/buff|speed/debuff
+      knight: attack_speed/buff|health/buff|ranged_damage/debuff
+      naive: attack_speed/buff|melee_damage/buff|armor/debuff
+      horse: attack_speed/buff|speed/buff|melee_damage/debuff
       bear: health/buff|melee_damage/buff|attack_speed/debuff
+      cleric: health/buff|ranged_damage/buff|armor/debuff
       soldier: health/buff|ranged_damage/buff|attack_speed/debuff
       scout: health/buff|speed/buff|armor/debuff
-      horse: speed/buff|attack_speed/buff|melee_damage/debuff
-      monkey: speed/buff|ranged_damage/buff|health/debuff
-      turtle: health/buff|armor/buff|speed/debuff
+      beater: melee_damage/buff|ranged_damage/buff|attack_speed/debuff
+      kamikaze: melee_damage/buff|ranged_damage/buff|health/debuff
+      barbarian: melee_damage/buff|ranged_damage/buff|speed/debuff
+      pegasus: melee_damage/buff|speed/buff|armor/debuff
+      silverstrike: melee_damage/buff|speed/buff|health/debuff
+      monkey: ranged_damage/buff|speed/buff|health/debuff
+      valkyrie: ranged_damage/buff|speed/buff|armor/debuff
     ###### RARE ######
     #### buff/buff ###
     2:
-      swordsman: attack_speed/buff|health/buff
+      tortoise: armor/buff|health/buff
+      paladin: armor/buff|melee_damage/buff
+      chief: armor/buff|ranged_damage/buff
+      steamroller: armor/buff|speed/buff
       assassin: attack_speed/buff|armor/buff
+      swordsman: attack_speed/buff|health/buff
+      sabre: attack_speed/buff|melee_damage/buff
       warrior: melee_damage/buff|health/buff
+      pirate: melee_damage/buff|speed/buff
+      tank: ranged_damage/buff|armor/buff
       ranger: ranged_damage/buff|health/buff
       tank: ranged_damage/buff|armor/buff
       quicksilver: speed/buff|health/buff
-      tortoise: armor/buff|health/buff
   ## INTERNALS ##
   calculations:
     melee_damage: <[level].*[3]>

--- a/denizen_scripts/survival/repo-link/items/system/soul_item_system.dsc
+++ b/denizen_scripts/survival/repo-link/items/system/soul_item_system.dsc
@@ -97,7 +97,6 @@ item_system_global_data:
       pirate: melee_damage/buff|speed/buff
       tank: ranged_damage/buff|armor/buff
       ranger: ranged_damage/buff|health/buff
-      tank: ranged_damage/buff|armor/buff
       quicksilver: speed/buff|health/buff
   ## INTERNALS ##
   calculations:


### PR DESCRIPTION
I have added more soul types. There are now 6 common souls, one for each effect. There are 20 uncommon souls, and 12 rare souls. I might rename some of the souls, to better reflect what the soul does. I will possibly change some of the soul debuffs to `ranged_damage` as there are not a lot of souls with that debuff as I intended.

> Update 8f19d08: I have spotted a duplicate line in the configuration. (Tank) This was from the merging my local branch `soul_types` to my local `master` branch. I have fixed the issue in this commit.

Squashed commit of the following:
commit 7815106a9a9789e838605b5b34207b9b3f54c48b
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Mon Jul 27 17:12:08 2020 -0400

    Add 1 rare soul.

commit d215a5f690d1bf1f9dc99274cc714003c5c20425
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Mon Jul 27 17:09:12 2020 -0400

    Add 3 uncommon souls.

commit 37b4a9a65b14db0278917160e449e001ef19dbe9
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Mon Jul 27 16:55:59 2020 -0400

    Added 2 uncommon souls.

commit e935c82765e543f9ed447c8592c491d66d658379
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Mon Jul 27 16:45:21 2020 -0400

    Added 3 uncommon souls.

commit 0e2135b434ec2b7d07518f44129803ee98b63cbd
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Mon Jul 27 15:47:42 2020 -0400

    Added 3 souls.