### PR TITLE
Issue 50 Pt. 2 - /bugreport

### DIFF
--- a/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/functions/mod_notifier.dsc
+++ b/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/functions/mod_notifier.dsc
@@ -37,12 +37,12 @@ mod_notify_action:
       - define message "<[message]> for <[length].as_duration.formatted>."
     - else:
       - define message <[message]>.
-    - if <bungee.list_servers.size||0> > 1:
+    - if <bungee.connected>:
       - bungeerun <bungee.list_servers> mod_message_staff def:<[message]>
     - else:
       - run mod_message_staff def:<[message]>
 
-# -- Notify online staff about reports.
+# -- Notify online staff about player reports.
 mod_notify_report:
   type: task
   debug: true
@@ -56,6 +56,19 @@ mod_notify_report:
     - else:
       - run mod_message_staff def:<[message]>
 
+# -- Notify online staff about reports.
+mod_notify_bugreport:
+  type: task
+  debug: true
+  definitions: reporter|reason|server
+  script:
+    - define reporter <[reporter].as_player.name>
+    - define message "<&2>[<&a><&l><[server]><&2>] <&a><[reporter]> <&e>has reported a bug: <&2><[reason]>."
+    - if <bungee.connected>:
+      - bungeerun <bungee.list_servers> mod_message_staff def:<[message]>
+    - else:
+      - run mod_message_staff def:<[message]>
+
 # -- Notify online staff about unbans.
 mod_notify_unban:
   type: task
@@ -64,7 +77,7 @@ mod_notify_unban:
   script:
     - define moderator <[moderator].as_player.name||Server>
     - define message "<&c>[!] <&b><[moderator]> has unbanned <[uuid].as_player.name>, who was <tern[<element[<[global]||null>].is[!=].to[null]>].pass[globally<&sp>].fail[]>banned for <[infraction]>, with the reason: <[reason]>"
-    - if <bungee.list_servers.size||0> > 1:
+    - if <bungee.connected>:
       - bungeerun <bungee.list_servers> mod_message_staff def:<[message]>
     - else:
       - run mod_message_staff def:<[message]>

--- a/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/tools/mod_report.dsc
+++ b/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/tools/mod_report.dsc
@@ -4,7 +4,7 @@ mod_report_command:
   name: report
   description: Report a player for chat & in-game behaviour.
   usage: /report [username] [reason]
-  tab completions:
+  tab complete:
     - define players <server.online_players.parse[name].exclude[<player.name>]>
     - if <context.args.is_empty>:
       - determine <[players]>
@@ -28,3 +28,20 @@ mod_report_command:
     - else:
       - narrate "<&c>Invalid player name entered."
       - narrate "<&c>Use /report [username] [reason]."
+
+mod_bugreport_command:
+  type: command
+  debug: true
+  name: bugreport
+  description: Report a bug to staff members.
+  usage: /bugreport [username] [reason]
+  script:
+    - if <context.args.is_empty>:
+      - narrate "<&c>Adriftus Bug Reporter"
+      - narrate "<&6>/bugreport [reason]"
+    - else:
+      - define reason <context.args.get[1].to[<context.args.size>].space_separated>
+      - run mod_notify_bugreport def:<list[<player>].include_single[<[reason]>].include[<bungee.server||Server>]>
+      # -- TODO: Send a webhook embed message to the bug reports channel in the public Discord server.
+      # -- >>>>: A webhook integration has to be set up for this to work.
+      - narrate "<&e>You have successfully reported a bug: <[reason]>."


### PR DESCRIPTION
The `/bugreport` command reports bugs to online staff. A webhook needs to be set up in the `#🐛bug-reports` channel in the public Discord server. This ensures staff members can see reports in the Discord server.
---
Squashed commit of the following:
commit 0abf546c840c39b0d76700636e86534d49f76fae
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Fri Aug 21 15:22:52 2020 -0400

    Add bug report command.

commit afdf29501776e8a4202dfe16fe048f9c2dca4c9e
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Fri Aug 21 15:13:38 2020 -0400

    Fix YAML key.

commit 82593106fc738fd7b0b85ce63683e33a672f5051
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Fri Aug 21 15:12:23 2020 -0400

    Update if statements for other notify tasks.