### PR TITLE
Add Discord message task to /report & /bugreport.

### DIFF
--- a/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/functions/mod_message_discord.dsc
+++ b/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/functions/mod_message_discord.dsc
@@ -1,4 +1,3 @@
-# -- Move to mod_functions.dsc, later.
 mod_message_discord:
   type: task
   debug: false

--- a/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/mod_main.dsc
+++ b/denizen_scripts/hub1/repo-link/Adriftus_Moderator_Panel/mod_main.dsc
@@ -3,7 +3,6 @@
 # - MAKE COMMAND DEFINITIONS CONSISTENT BETWEEN COMMANDS. (Definition name, value, usage, etc.)
 # - EXPAND CHAT (UN)MUTE FUNCTION.
 # - Use <context.args.is_empty> instead of `<context.args.first||null> == null`.
-# -> Add report commands, that will notify staff and a Discord channel.
 # - Replace nested foreach loop in mod_get_infractions procedure in mod_infractions.
 # - Split panel scripts up into a folder.
 


### PR DESCRIPTION
This pull request adds a Discord webhook message task to /report & /bugreport. A webhook should be set up in `#🐛bug-reports` in the public Discord server, and `#action-log` in the staff Discord server, for this to be tested.
---
Squashed commit of the following:

commit 87cd46ace08680d4ee8b606f0250382209168507
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Sat Aug 22 17:37:24 2020 -0400

    Complete To-Do list entry.

commit 87c60214726599924a38aa4684a4268a0655b857
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Sat Aug 22 17:36:17 2020 -0400

    Add Discord message task.