### PR TITLE
Teleportation Crystals: Feature Request -- Issue 46 Part 1

### DIFF
--- a/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
+++ b/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
@@ -5,7 +5,7 @@ teleportation_crystal:
   material: firework_star
   display name: <&b><&o>Teleportation Crystal
   lore:
-    - "<&3>Right Click to open up the teleportation menu."
+    - <&3>Right Click to open up the teleportation menu.
   mechanisms:
     hides: ALL
 
@@ -25,17 +25,17 @@ teleportation_crystal_menu:
     - define inventory <list>
     - foreach <server.online_players> as:player:
       - define lore <list[<&b>Left<&sp>Click<&sp>to<&sp>teleport<&sp>to<&co><&sp><&e><[player].name>]>
-      - define lore:|:<&3>Right<&sp>Click<&sp>to<&sp>request<&sp>to<&sp>teleport<&sp>here
+      - define lore:->:<&3>Right<&sp>Click<&sp>to<&sp>request<&sp>to<&sp>teleport<&sp>here
       - define item <item[player_head].with[display_name=<&e><[player].name>;lore=<[lore]>;skull_skin=<[player].name>;nbt=<list[name/<[player].name>]>]>
       - define inventory:->:<[item]>
     - determine <[inventory]>
   slots:
-    - "[] [] [] [] [] [] [] [] []"
-    - "[] [] [] [] [] [] [] [] []"
-    - "[] [] [] [] [] [] [] [] []"
-    - "[] [] [] [] [] [] [] [] []"
-    - "[] [] [] [] [] [] [] [] []"
-    - "[b2] [b1] [b1] [b2] [close] [b2] [b1] [b1] [b2]"
+    - [] [] [] [] [] [] [] [] []
+    - [] [] [] [] [] [] [] [] []
+    - [] [] [] [] [] [] [] [] []
+    - [] [] [] [] [] [] [] [] []
+    - [] [] [] [] [] [] [] [] []
+    - [b2] [b1] [b1] [b2] [close] [b2] [b1] [b1] [b2]
 
 # -- Teleportation Crystal Menu Events
 # -> Left Click to request to teleport to player.
@@ -49,11 +49,8 @@ teleportation_crystal_menu_events:
     
     on player left clicks player_head in teleportation_crystal_menu:
       - define other_player <server.match_offline_player[<context.item.nbt[name]>]>
-      # Player Verification dependency
-      - define user <[other_player]>
-      - inject player_verification
       # Check if the other player has a map with your player tag.
-      - if <[other_player].has_flag[teleportation_crystal]>:
+      - if <[other_player].has_flag[teleportation_crystal]> && <[other_player].is_online>:
         - foreach <[other_player].flag[teleportation_crystal]> as:map:
           - if <[map].contains[<player>]>:
             - define inner_map <[map].get[<player>].as_map>
@@ -74,11 +71,8 @@ teleportation_crystal_menu_events:
     
     on player right clicks player_head in teleportation_crystal_menu:
       - define other_player <server.match_offline_player[<context.item.nbt[name]>]>
-      # Player Verification dependency
-      - define user <[other_player]>
-      - inject player_verification
       # Check if the other player has a map with your player tag.
-      - if <[other_player].has_flag[teleportation_crystal]>:
+      - if <[other_player].has_flag[teleportation_crystal]> && <[other_player].is_online>:
         - foreach <[other_player].flag[teleportation_crystal]> as:map:
           - if <[map].contains[<player>]>:
             - define inner_map <[map].get[<player>].as_map>

--- a/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
+++ b/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
@@ -83,7 +83,7 @@ teleportation_crystal_menu_events:
           - if <[map].contains[<player>]>:
             - define inner_map <[map].get[<player>].as_map>
             - if <[inner_map].get[request_type]> == teleport_to:
-              - teleport <player> <[inner_map].get[location].as_location>
+              - teleport <[other_player]> <[inner_map].get[location].as_location>
               - flag <[other_player]> teleportation_crystal:<-:<[map]>
               - flag <player> teleportation_crystal:<-:<[map].with[<[other_player]>].as[<[inner_map].with[request_type].as[teleport_here]>]>
               - take scriptname:teleportation_crystal from:<[other_player].inventory>

--- a/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
+++ b/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
@@ -1,0 +1,99 @@
+# -- Teleportation Crystal
+teleportation_crystal:
+  type: item
+  debug: false
+  material: firework_star
+  display name: <&b><&o>Teleportation Crystal
+  lore:
+    - "<&3>Right Click to open up the teleportation menu."
+  mechanisms:
+    hides: ALL
+
+# -- Teleportation Crystal Menu
+teleportation_crystal_menu:
+  type: inventory
+  debug: true
+  title: <&b>Teleportation Crystal
+  inventory: CHEST
+  size: 54
+  definitions:
+    x: <item[air]>
+    b1: <item[light_blue_stained_glass_pane].with[display_name=<&r>]>
+    b2: <item[cyan_stained_glass_pane].with[display_name=<&r>]>
+    close: <item[red_stained_glass_pane].with[display_name=<&c>Cancel]>
+  procedural items:
+    - define inventory <list>
+    - foreach <server.online_players> as:player:
+      - define lore <list[<&b>Left<&sp>Click<&sp>to<&sp>teleport<&sp>to<&co><&sp><&e><[player].name>]>
+      - define lore:|:<&3>Right<&sp>Click<&sp>to<&sp>request<&sp>to<&sp>teleport<&sp>here
+      - define item <item[player_head].with[display_name=<&e><[player].name>;lore=<[lore]>;skull_skin=<[player].name>;nbt=<list[name/<[player].name>]>]>
+      - define inventory:->:<[item]>
+    - determine <[inventory]>
+  slots:
+    - "[] [] [] [] [] [] [] [] []"
+    - "[] [] [] [] [] [] [] [] []"
+    - "[] [] [] [] [] [] [] [] []"
+    - "[] [] [] [] [] [] [] [] []"
+    - "[] [] [] [] [] [] [] [] []"
+    - "[b2] [b1] [b1] [b2] [close] [b2] [b1] [b1] [b2]"
+
+# -- Teleportation Crystal Menu Events
+# -> Left Click to request to teleport to player.
+# -> Right Click to request to teleport player here.
+teleportation_crystal_menu_events:
+  type: world
+  debug: true
+  events:
+    on player clicks in teleportation_crystal_menu priority:10:
+      - determine cancelled
+    
+    on player left clicks player_head in teleportation_crystal_menu:
+      - define other_player <server.match_offline_player[<context.item.nbt[name]>]>
+      # Player Verification dependency
+      - define user <[other_player]>
+      - inject player_verification
+      # Check if the other player has a map with your player tag.
+      - if <[other_player].has_flag[teleportation_crystal]>:
+        - foreach <[other_player].flag[teleportation_crystal]> as:map:
+          - if <[map].contains[<player>]>:
+            - define inner_map <[map].get[<player>].as_map>
+            - if <[inner_map].get[request_type]> == teleport_here:
+              - teleport <player> <[inner_map].get[location].as_location>
+              - flag <[other_player]> teleportation_crystal:<-:<[map]>
+              - flag <player> teleportation_crystal:<-:<[map].with[<[other_player]>].as[<[inner_map].with[request_type].as[teleport_to]>]>
+              - take scriptname:teleportation_crystal from:<[other_player].inventory>
+              - take scriptname:teleportation_crystal from:<player.inventory>
+              - stop
+      # Request to teleport to another player.
+      - define teleport_map <map.with[<player>].as[<map.with[request_type].as[teleport_to].with[location].as[<player.location>]>]>
+      - flag <[other_player]> teleportation_crystal:->:<[teleport_map]> duration:3m
+      - flag <player> teleportation_crystal:->:<map.with[<[other_player]>].as[<[teleport_map].with[request_type].as[teleport_here]>]> duration:3m
+      - narrate targets:<[other_player]> "<&3><player.name> <&b>requests to teleport to you!"
+      - narrate targets:<[other_player]> "<&b>Use a teleportation crystal to confirm their request. <&3>(Teleport here: <player.name>)"
+      - narrate "<&b>You requested to teleport to <&3><[other_player].name>."
+    
+    on player right clicks player_head in teleportation_crystal_menu:
+      - define other_player <server.match_offline_player[<context.item.nbt[name]>]>
+      # Player Verification dependency
+      - define user <[other_player]>
+      - inject player_verification
+      # Check if the other player has a map with your player tag.
+      - if <[other_player].has_flag[teleportation_crystal]>:
+        - foreach <[other_player].flag[teleportation_crystal]> as:map:
+          - if <[map].contains[<player>]>:
+            - define inner_map <[map].get[<player>].as_map>
+            - if <[inner_map].get[request_type]> == teleport_to:
+              - teleport <player> <[inner_map].get[location].as_location>
+              - flag <[other_player]> teleportation_crystal:<-:<[map]>
+              - flag <player> teleportation_crystal:<-:<[map].with[<[other_player]>].as[<[inner_map].with[request_type].as[teleport_here]>]>
+              - take scriptname:teleportation_crystal from:<[other_player].inventory>
+              - take scriptname:teleportation_crystal from:<player.inventory>
+              - stop
+      # Request to teleport a player to you.
+      - define teleport_map <map.with[<player>].as[<map.with[request_type].as[teleport_here].with[location].as[<player.location>]>]>
+      - flag <[other_player]> teleportation_crystal:->:<[teleport_nap]> duration:3m
+      - flag <player> teleportation_crystal:->:<map.with[<[other_player]>].as[<[teleport_map].with[request_type].as[teleport_to]>]> duration:3m
+      - narrate targets:<[other_player]> "<&3><player.name> <&b>requests you to teleport to them!"
+      - narrate targets:<[other_player]> "<&b>Use a teleportation crystal to confirm their request. <&3>(Teleport to: <player.name>)"
+      - narrate "<&b>You requested <&3><[other_player].name> <&b>teleport to you."
+


### PR DESCRIPTION
This pull request fulfills the second requirement for [this feature request issue](https://github.com/Adriftus-Studios/network-script-data/issues/46).
It implements teleportation crystals, *without* the required crafting recipe. This will allow us to test the feature before we properly lock it behind a crafting recipe.

The next item to implement would be the recipe item: `Recipe: Teleportation Crystal`. This recipe item must be dropped by a mob with a low drop chance. An additional item needed to craft the teleportation crystal needs to be unlocked, preferably in a shop, when right-clicking with the recipe item.  [Reference](https://discordapp.com/channels/626078288556851230/669922990435336216/745693036230738010).
**When you merge these changes, please mark the second checkbox of Issue 46 as completed!**
**`[ ] Teleport Crystals` -> `[x] Teleport Crystals`**

**Feature Request -- Issue 46**
Squashed commit of the following:

commit 948b9ececc2dd3f93ecdd05f3ace36c9b8d41181
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 2 17:15:09 2020 -0400

    Teleport other player correctly.

commit 48897d94bb1b2e260c278290c8d4a87e18d0cced
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 2 17:04:30 2020 -0400

    Definition consistency updates.

commit 0a9a91f72b3c511f4c98309c462856796bfe1f30
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 2 17:01:06 2020 -0400

    Add teleport request messages.

commit 46e02766b6e8cc125a5f96e1736e9e46448fc398
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 2 16:52:27 2020 -0400

    Take items from both players.

commit 37ed823cb4e5f8394f0ef7c865220a5ede63d0f5
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 2 16:49:17 2020 -0400

    Initial teleportation crystal commit.
