### PR TITLE
Add teleportation crystal click event.

### DIFF
--- a/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
+++ b/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
@@ -99,3 +99,9 @@ teleportation_crystal_menu_events:
       - narrate targets:<[other_player]> "<&b>Use a teleportation crystal to confirm their request. <&3>(Teleport to: <player.name>)"
       - narrate "<&b>You requested <&3><[other_player].name> <&b>teleport to you."
 
+teleportation_crystal_events:
+  type: world
+  debug: false
+  events:
+    on player right clicks with teleportation_crystal:
+	  - inventory open d:teleportation_crystal_menu

--- a/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
+++ b/denizen_scripts/survival/repo-link/items/teleportation_crystals.dsc
@@ -103,5 +103,5 @@ teleportation_crystal_events:
   type: world
   debug: false
   events:
-    on player right clicks with teleportation_crystal:
+    on player right clicks block with:teleportation_crystal:
 	  - inventory open d:teleportation_crystal_menu


### PR DESCRIPTION
This pull request adds the missing item click event that was not present on the teleportation crystal item.