### PR TITLE
Add hub world protection. -- Issue 68

### DIFF
--- a/denizen_scripts/hub1/repo-link/systems/hub_protection.dsc
+++ b/denizen_scripts/hub1/repo-link/systems/hub_protection.dsc
@@ -1,0 +1,43 @@
+# -- Hub Protection Scripts
+hub_world_protection:
+  type: world
+  debug: false
+  events:
+    # - Cancel natural entity spawning.
+    on entity spawns:
+      - if <context.reason> == NATURAL:
+        - determine cancelled
+    # - Cancel the placement of blocks.
+    on player places block:
+      - if !<player.has_flag[world.hub.modify]>:
+        - determine cancelled
+    # - Cancel the breakage of blocks.
+    on player breaks block:
+      - if !<player.has_flag[world.hub.modify]>:
+        - determine cancelled
+    # - Cancel creative mode block breakage.
+    on player clicks block bukkit_priority:HIGHEST:
+      - if !<player.has_flag[world.hub.modify]> && !<player.has_flag[world.hub.can_shoot]>:
+        - determine cancelled
+
+
+# -- Anti-Damage Events
+hub_player_takes_damage:
+  type: world
+  debug: false
+  events:
+    # - Anti-Player Damage ~(>_<~)
+    on player damaged:
+      - determine cancelled
+
+    # - Anti-Hunger (￣︿￣)
+    on player changes food level:
+      - determine 20
+
+    # - Anti-Drowning 〜(＞＜)〜
+    on player changes air level:
+      - determine cancelled
+
+    # - Save the bees! ヽ(￣ω￣(。。 )ゝ
+    on bee damaged by player:
+      - determine cancelled


### PR DESCRIPTION
This pull request resolves [Issue 68](https://github.com/Adriftus-Studios/network-script-data/issues/68). The [spawn protection scripts](https://github.com/Adriftus-Studios/network-script-data/blob/master/denizen_scripts/survival/repo-link/spawn_scripts/spawn_protection.dsc) from Survival+ have been copied and adapted for the Hub server. The events no longer check for a spawn cuboid, as a spawn cuboid is not used by other hub systems.

I have tested what happens on the new hub world, `4_buildings`.
When I teleported to the world's spawn location and jumped off the platform, I instantly died from the fall damage. The event [`player takes damage`](https://one.denizenscript.com/denizen/evts/entity%20damaged) includes fall damage ([FALL](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/entity/EntityDamageEvent.DamageCause.html#FALL)) as a cause of damage. With this pull request, players will no longer have to suffer the pains of falling from a great height and *not* living to tell the tale.
**When you merge this pull request, please mark and close Issue 68 as resolved!**

**Add hub world protection.**
Squashed commit of the following (Local branch 'protecc'):

commit 45fe55655f8498df3506a63171fe9ec48081152f
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Mon Sep 7 22:58:35 2020 -0400

    Add hub world protection.