### PR TITLE
Fixes to Tiered Potions.

### DIFF
--- a/denizen_scripts/survival/repo-link/items/tiered_potions.dsc
+++ b/denizen_scripts/survival/repo-link/items/tiered_potions.dsc
@@ -51,14 +51,17 @@ tiered_potions_events:
       - determine passively cancelled
       - define item <context.item>
       - heal <script[tiered_potions_data].data_key[<context.item.script.name>.heals].mul[2]>
-      - adjust <[item]> nbt:<list[uses/<[item].nbt[uses].add[1]||1>]>
-      - if <[item].nbt[uses]> >= <script[tiered_potions_data].data_key[<context.item.script.name>.uses]>:
-        # -- If `- determine <[item]>` doesn't work, try `- determine <context.item>` or `- determine cancelled:false`.
+      - adjust <[item]> nbt:<list[uses/<[item].nbt[uses].add[1]||1>]> save:item
+      - if <entry[item].result.nbt[uses]> >= <script[tiered_potions_data].data_key[<context.item.script.name>.uses]>:
+        # -- If `- determine <[item]>` doesn't work, try `- determine <entry[item].result>` or `- determine cancelled:false`.
         - playsound <player> sound:ENTITY_ITEM_BREAK
         - determine <[item]>
       # Wait one tick, then update the potion's NBT.
       - wait 1t
-      - inventory adjust slot:<player.held_item_slot> nbt:<list[uses/<[item].nbt[uses]>]>
+      - if <player.item_in_hand> == <context.item>:
+        - inventory adjust slot:<player.held_item_slot> nbt:<list[uses/<entry[item].result.nbt[uses]>]>
+      - else:
+        - inventory adjust slot:<player.inventory.find[<player.item_in_offhand>]> nbt:<list[uses/<entry[item].result.nbt[uses]>]>
 
 
 # -- Tiered Potions
@@ -82,12 +85,12 @@ tiered_potion_2:
       type: shaped
       output_quantity: 1
       input:
-      - <item[potion].with[potion_effects=<list[INSTANT_HEAL,false,false]>]>|<script[tiered_potions_data].data_key[<script.name>.item]>|<item[potion].with[potion_effects=<list[INSTANT_HEAL,false,false]>]>
+      - potion[potion_effects=INSTANT_HEAL,false,false]|<script[tiered_potions_data].data_key[<script.name>.item]>|potion[potion_effects=INSTANT_HEAL,false,false]
     2:
       type: shaped
       output_quantity: 1
       input:
-      - <item[potion].with[potion_effects=<list[INSTANT_HEAL,true,false]>]>|<script[tiered_potions_data].data_key[<script.name>.item]>|<item[potion].with[potion_effects=<list[INSTANT_HEAL,true,false]>]>
+      - potion[potion_effects=INSTANT_HEAL,true,false]|<script[tiered_potions_data].data_key[<script.name>.item]>|potion[potion_effects=INSTANT_HEAL,true,false]
 
 # - 3
 tiered_potion_3:


### PR DESCRIPTION
These are some fixes to the tiered potions. Currently testing: Usage incrementation, tier 2 crafting recipe, proper disposal of potions once fully used, ~~tier 3-10 crafting recipes.~~

**Fixes to Tiered Potions.**
Squashed commit of the following:

commit 9e30a2fae3a8ae0ce1748e22ea2f7ac04b5ea479
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Tue Sep 8 23:39:40 2020 -0400

    Attempt fixing tier 2 crafting recipe.

commit d15d256bd595e4bdac5f4f68003634c4627e7bd6
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Tue Sep 8 23:34:40 2020 -0400

    Add player held item slot checks.

commit ceb59bcd94d1be80f2d1cfcf5db25041dbaaaec9
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Tue Sep 8 23:31:16 2020 -0400

    Fix inventory adjust.

commit ecde922a5ac381f4ecbf5b8035b0aa7167603d9e
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Tue Sep 8 23:28:53 2020 -0400

    Fix determine.

commit 7b7403e4cd3137a6ad05db6e8e046796fc2a7cee
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Tue Sep 8 23:27:37 2020 -0400

    Fix uses check.