### PR TITLE
Add uptime to status command.

### DIFF
--- a/denizen_scripts/relay/repo_link/commands/status.dsc
+++ b/denizen_scripts/relay/repo_link/commands/status.dsc
@@ -69,7 +69,7 @@ Status_DCommand:
       - define Flags <list[-o]>
   # % ██ [ All Flag ] ██
     - else if <list[-a|-all].contains_any[<[Args]>]>:
-      - define Flags <list[-o|-p|-w|-pl|-v|-ch|-tps|-s]>
+      - define Flags <list[-o|-p|-w|-pl|-v|-ch|-tps|-s|-u]>
     - else:
       - define Flags <[Args].remove[first]>
     
@@ -102,7 +102,7 @@ Status_DCommand:
         - define Field <[Field].with[value].as[<entry[Data].result>]>
         - define Fields <[Fields].include[<[Field]>]>
     
-  # % ██ [ Build Data
+  # % ██ [ Build Data ] ██
   #^- define Data "<map.with[title].as[<[Server]> Status]>"
     - define Data "<map.with[color].as[code].with[fields].as[<[Fields]>].with[username].as[<[Server]> Server].with[avatar_url].as[https://cdn.discordapp.com/attachments/625076684558958638/739228903700168734/icons8-code-96.png]>"
     - if !<[Duplicates].exclude[Online].is_empty>:
@@ -152,3 +152,8 @@ Status_DCommand:
       nodes:
         - s
         - scripts
+    Uptime:
+      tag: "Real<&co> `<server.real_time_since_start.formatted>`<n>Delta<&co> `<server.delta_time_since_start.formatted>`"
+      nodes:
+        - u
+        - uptime


### PR DESCRIPTION
This pull request adds the `-u`/`-uptime` flag to the `/status` Discord command. It shows a server's uptime in real and delta time.
When you merge this pull request, I will update the `Status.yml` and `StatusDCmd.yml` files with updated help text on the dedicated server.

**Add uptime to status command.**
Squashed commit of the following:

commit 253b158ab635703779b60efe9883d446b5eab883
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 9 23:15:39 2020 -0400

    Update status.dsc

commit 9a191dc8abd848688e0c6aeb18c5f7be6addbd9f
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 9 23:01:35 2020 -0400

    Add uptime to status command.