### PR TITLE
Grant advancements when earning achievements. -- Issue 101

### DIFF
--- a/denizen_scripts/global/server/achievements.dsc
+++ b/denizen_scripts/global/server/achievements.dsc
@@ -1,5 +1,5 @@
 achievement_data:
-  type: yaml data
+  type: data
   GUI:
     - '&a----------------------------------'
     - '&a- <[name]>'
@@ -7,16 +7,29 @@ achievement_data:
     - '&a- <[description]>'
     - '&a- <[reward_text]>'
     - '&a----------------------------------'
+  parents:
+    survival:
+      icon: grass_block
+      name: 'Survival'
+      description: 'Adriftus Survival'
+      background: 'minecraft:textures/gui/advancements/backgrounds/stone.png'
   achievements:
     First_RTP:
       reward:
         script: title_unlock/Explorer
         text: '&bYou have unlocked a new title!'
-      description: '&eYou have started your journey by randomly teleporting for the first time.'
+      icon: ender_pearl
       name: '&6Your First RTP'
+      description: '&eYou have started your journey by randomly teleporting for the first time.'
+      parent: survival
+      frame: task
+      announce: false
+      hidden: false
+      offset:
+        x: 0
+        y: 0
 
-
-Achievement_give:
+achievement_give:
   type: task
   definitions: id
   script:
@@ -29,3 +42,17 @@ Achievement_give:
       - foreach <script[achievement_data].data_key[GUI].parse[parse_color.parsed]>:
         - narrate <[value]>
       - run <script[achievement_data].data_key[achievements.<[id]>.reward.script].before[/]> def:<script[achievement_data].data_key[achievements.<[id]>.reward.script].after[/]>
+      - advancement id:<[id]> grant:<player>
+
+achievement_data_load:
+  type: world
+  debug: false
+  events:
+    on server start:
+      # -- Create list of parents (root advancements) achievements will use.
+      - foreach <script[achievement_data].list_keys[parents]> as:id:
+        - advancement id:<[id]> icon:<script[achievement_data].data_key[parents.<[id]>.icon]> title:<script[achievement_data].data_key[parents.<[id]>.name]> description:<script[achievement_data].data_key[parents.<[id]>.description]> background:<script[achievement_data].data_key[parents.<[id]>.background]>
+
+      # -- Create list of achievements as in-game advancements.
+      - foreach <script[achievement_data].list_keys[achievements]> as:id:
+        - advancement id:<[id]> parent:<script[achievement_data].data_key[achievements.<[id]>.parent]> icon:<script[achievement_data].data_key[achievements.<[id]>.icon]> title:<script[achievement_data].data_key[achievements.<[id]>.name].parse_color> description:<script[achievement_data].data_key[achievements.<[id]>.description].parse_color> frame:<script[achievement_data].data_key[achievements.<[id]>.frame]> hidden:<script[achievement_data].data_key[achievements.<[id]>.hidden]> x:<script[achievement_data].data_key[achievements.<[id]>.offset.x]> y:<script[achievement_data].data_key[achievements.<[id]>.offset.y]>

--- a/denizen_scripts/survival/repo_link/spawn_scripts/survival_rtp.dsc
+++ b/denizen_scripts/survival/repo_link/spawn_scripts/survival_rtp.dsc
@@ -18,7 +18,7 @@ survival_rtp:
   #^  - if !<yaml[global.player.<player.uuid>].contains[titles.unlocked.explorer]>:
     - if !<yaml[global.player.<player.uuid>].read[titles.unlocked].contains[Explorer]||false>:
       - define id First_RTP
-      - inject Achievement_give
+      - inject achievement_give
     - wait 1m
     - narrate "<&c>You now take fall damage as normal."
 


### PR DESCRIPTION
This pull request resolves [Issue 101](https://github.com/Adriftus-Studios/network-script-data/issues/101). Advancements are created on server start.
Achievements can be attached to a parent, using the `parent` key. Currently, the only parent is `survival`. Parents will show up as tabs in the advancements menu.
The name (title) and description are being colour-parsed. Hopefully, Minecraft allows you to colour the text in the advancements menu.
An offset of x and y can be defined to offset the position of the advancement in the menu. I will figure out if the parent advancements need an offset defined, like their child advancements.

**Grant advancements when earning achievements.**
Squashed commit of the following:

commit f73d44bec6f66e90aac5c5fba2397b2ba8c50daa
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 16 22:42:47 2020 -0400

    Grant advancement on achievement give.

commit a3ff912af9d30e29715feacbf49cf9826f37c64c
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 16 22:41:04 2020 -0400

    Add advancement offset.

commit 3af1b8a554f325008dc1e44fdd453d23b3aed69d
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 16 22:37:44 2020 -0400

    Create advancements on server start.

commit c0d6b58c9cb5795dbae8e0988e8aa8abc14b4332
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 16 22:19:06 2020 -0400

    Add advancement command args.

commit 35bf4fd66d8812264db9e4b07e87d7b897074993
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Wed Sep 16 22:12:41 2020 -0400

    Consistency changes.