### PR TITLE
Release stage command and flagger.

### DIFF
--- a/denizen_scripts/global/server/commands/releaser.dsc
+++ b/denizen_scripts/global/server/commands/releaser.dsc
@@ -1,0 +1,31 @@
+release_stage_command:
+  type: command
+  debug: false
+  name: release_stage
+  description: Set the release stage of the server.
+  usage: /release_stage [alpha|beta|release]
+  permission: adriftus.admin
+  tab complete:
+    - define args <list[alpha|beta|release]>
+    - inject onearg_command_tabcomplete
+  script:
+    - if <context.args.is_empty>:
+      - narrate <server.flag[release_stage].to_titlecase||Release>
+    - else if <context.args.get[1]> == alpha:
+      - flag server release_stage:alpha
+      - narrate "<&a>Set the server release stage to Alpha."
+    - else if <context.args.get[1]> == beta:
+      - flag server release_stage:beta
+      - narrate "<&b>Set the server release stage to Beta."
+    - else if <context.args.get[1]> == release:
+      - flag server release_stage:release
+      - narrate "<&e>Set the server release stage to Release."
+    - else:
+      - narrate "<&c>Invalid release mode entered."
+
+release_stage_join_event:
+  type: world
+  debug: false
+  events:
+    after player joins:
+      - flag <player> <server.flag[release_stage]||release>


### PR DESCRIPTION
This pull request resolves [Issue 112](https://github.com/Adriftus-Studios/network-script-data/issues/112). A command to set the release stage has been implemented. On join, players will be flagged `alpha`, `beta`, and `release`, based on the `release_stage` server flag. Other Denizen scripts can check if the player has any one of those three flags and give rewards accordingly.

**Release stage command and flagger.**
commit fdbcd3c5f42364633d1ad1b982d3069102c3678a (HEAD -> kyu, origin/kyu, i-112)
Author: ChrispyMC <ChrispyMC@users.noreply.github.com>
Date:   Sat Sep 19 20:01:57 2020 -0400

    Release stage command and flagger.

