### PR TITLE
fix: Unparsed tag on Claims Shop (I-107)

### DIFF
--- a/denizen_scripts/survival/repo_link/global_systems/chunk_claim_protection.dsc
+++ b/denizen_scripts/survival/repo_link/global_systems/chunk_claim_protection.dsc
@@ -1,5 +1,5 @@
 claim_system_yaml_settings:
-  type: yaml data
+  type: data
   settings:
     allowed_worlds: mainland
 
@@ -7,7 +7,7 @@ claim_system_yaml_settings:
 ## YAML DATA FOR UPGRADE PRICES ##
 ##################################
 claiming_system_upgrade_data:
-  type: yaml data
+  type: data
   debug: false
   upgrades:
     fly:

--- a/denizen_scripts/survival/repo_link/shops/claim_upgrades_shop.dsc
+++ b/denizen_scripts/survival/repo_link/shops/claim_upgrades_shop.dsc
@@ -27,7 +27,7 @@ claiming_protection_group_upgrades:
       - define material <script[claiming_system_upgrade_data].data_key[upgrades.<[upgrade]>.material]>
       - define "lore:<&a>---------------------|<&e>Price<&co><&sp><&a><[cost]>|<&b>Use this item in a claim.|<&b>This will unlock <[name]>|<&a>---------------------"
       - define list:->:<item[claiming_group_upgrade_item].with[material=<[material]>;display_name=<[name]>;lore=<[lore]>;nbt=upgrade/<[upgrade]>|cost/<[cost]>]>
-    - define cost <script[claiming_system_upgrade_data].data_key[upgrades.claim_limit.cost].parsed>
+    - define cost <script[claiming_system_upgrade_data].parsed_key[upgrades.claim_limit.cost]>
     - define "lore:<&a>---------------------|<&e>Price<&co><&sp><&a><[cost]>|<&b>Right click while holding.|<&b>This will unlock <&a>10 <&b>more claims.|<&a>---------------------
     - define list:->:<item[claiming_group_upgrade_item].with[material=gold_block;display_name=<&b>Upgrade<&sp>Claim<&sp>Limit;lore=<[lore]>;nbt=upgrade/claim_limit|cost/<[cost]>]>
     - determine <[list]>


### PR DESCRIPTION
This pull request resolves [Issue 107](https://github.com/Adriftus-Studios/network-script-data/issues/107). I have updated the script type for two data script containers from `yaml data` to `data`.
The tag `<script[claiming_system_upgrade_data].data_key[upgrades.claim_limit.cost].parsed>` has been updated to `<script[claiming_system_upgrade_data].parsed_key[upgrades.claim_limit.cost]>`.

**fix: Unparsed tag on Claims Shop (I-107)**
Squashed commit of the following:

commit 2d84b91fecd342a62bf7cab05a20edc364042394
Author: ChrispyMC <32986257+ChrispyMC@users.noreply.github.com>
Date:   Sat Oct 3 10:48:01 2020 -0400

    Replace data_key[].parsed with parsed_key.

commit 122939edff951610d7e65044c6d4e26d1fc24725
Author: ChrispyMC <32986257+ChrispyMC@users.noreply.github.com>
Date:   Sat Oct 3 10:46:25 2020 -0400

    Update script types.