### PR TITLE
Changes to econ and grappling hook

### DIFF
--- a/denizen_scripts/survival/repo_link/items/grappling_hook.dsc
+++ b/denizen_scripts/survival/repo_link/items/grappling_hook.dsc
@@ -21,7 +21,7 @@ grappling_hook_events:
         - narrate "<&c>You can only fire one grappling hook at a time."
         - stop
       - shoot arrow shooter:<player> speed:3 script:grappling_hook_pull save:hook
-      - flag player grappling:true duration:10s
+      - flag player grappling:true duration:3s
       - wait 1t
       - flag <entry[hook].shot_entity> no_trail:true duration:30s
       - repeat 999:

--- a/denizen_scripts/survival/repo_link/shops/market_system.dsc
+++ b/denizen_scripts/survival/repo_link/shops/market_system.dsc
@@ -52,13 +52,14 @@ market_system_data:
       lore: <&a>Trade Goods!
   items:
     # Crafting
-    netherite_ingot:
-      category: crafting
-      minimum_value: 2200
+#    -- Nether stuff can come later, this is currently OP.
+#    netherite_ingot:
+#      category: crafting
+#      minimum_value: 2200
 
-    ancient_debris:
-      category: crafting
-      minimum_value: 500
+#    ancient_debris:
+#      category: crafting
+#      minimum_value: 500
 
     diamond:
       category: crafting

--- a/denizen_scripts/survival/repo_link/shops/market_system.dsc
+++ b/denizen_scripts/survival/repo_link/shops/market_system.dsc
@@ -57,9 +57,6 @@ market_system_data:
 #      category: crafting
 #      minimum_value: 2200
 
-#    ancient_debris:
-#      category: crafting
-#      minimum_value: 500
 
     diamond:
       category: crafting

--- a/denizen_scripts/survival/repo_link/shops/market_system.dsc
+++ b/denizen_scripts/survival/repo_link/shops/market_system.dsc
@@ -52,10 +52,6 @@ market_system_data:
       lore: <&a>Trade Goods!
   items:
     # Crafting
-#    -- Nether stuff can come later, this is currently OP.
-#    netherite_ingot:
-#      category: crafting
-#      minimum_value: 2200
 
 
     diamond:

--- a/denizen_scripts/survival/repo_link/shops/survivalist_shop.dsc
+++ b/denizen_scripts/survival/repo_link/shops/survivalist_shop.dsc
@@ -90,7 +90,7 @@ survivalistData:
             Prices: 1500/1300
         Grappling_Hook:
             Item: <item[grappling_hook]>
-            Prices: 100/50
+            Prices: 5000/1500
         Teleportation_Shard:
             Item: <item[teleportation_shard]>
             Prices: 500/250


### PR DESCRIPTION
Nerf to distance able to be travelled with the grappling hook
Removed netherite and ancient debris from the stonks shop
changed the price of the grappling hook from 100 to 5,000
changed the sell price of the grappling hook from 50 to 1500